### PR TITLE
Adapted code to run on Julia 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In this example, we'll use a custom hash function:
 
 	using HyperLogLog
 
-	counter = HLL(8, x -> uint32(hash(x)))
+	counter = HLL(8, x -> UInt32(my_hash_function(x)))
 
 	consume!(counter, 1:100)
 	estimate(counter)
@@ -37,4 +37,4 @@ In this example, we'll use a custom hash function:
 	consume!(counter, 101:1000)
 	estimate(counter)
 
-Note that the hash function must return a `Uint32`. This is done to be consistent with the theory presented in the original HyperLogLog paper. We may allow 64-bit hashes in the future.
+Note that the hash function must return a `UInt32`. This is done to be consistent with the theory presented in the original HyperLogLog paper. We may allow 64-bit hashes in the future.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.2-
+julia 0.4
+Murmur3

--- a/src/HyperLogLog.jl
+++ b/src/HyperLogLog.jl
@@ -1,88 +1,91 @@
 module HyperLogLog
-	include("utils.jl")
 
-	export HLL, consume!, estimate
+using Murmur3
 
-	type HLL
-		m::Uint32
-		M::Vector{Uint32}
-		mask::Uint32
-		altmask::Uint32
-		# h() must be a function of the form: Any -> Uint32
-		h::Function
-	end
+include("utils.jl")
 
-	function HLL(b::Integer, h::Function = hash32)
-		if !(4 <= b <= 16)
-			throw(ArgumentError("b must be an integer between 4 and 16"))
-		end
+export HLL, consume!, estimate
 
-		m = uint32(1) << b
+type HLL
+    m::UInt32
+    M::Vector{UInt32}
+    mask::UInt32
+    altmask::UInt32
+    # h() must be a function of the form: Any -> UInt32
+    h::Function
+end
 
-		M = zeros(Uint32, m)
+function HLL(b::Integer, h::Function = hash32)
+    if !(4 <= b <= 16)
+        throw(ArgumentError("b must be an integer between 4 and 16"))
+    end
+    
+    m = UInt32(1) << b
+    
+    M = zeros(UInt32, m)
 
-		mask = 0x00000000
-		for i in 1:(b - 1)
-			mask |= 0x00000001
-			mask <<= 1
-		end
-		mask |= 0x00000001
+    mask = 0x00000000
+    for i in 1:(b - 1)
+        mask |= 0x00000001
+        mask <<= 1
+    end
+    mask |= 0x00000001
+    
+    altmask = ~mask
+    
+    return HLL(m, M, mask, altmask, h)
+end
 
-		altmask = ~mask
+function Base.show(io::IO, counter::HLL)
+    @printf io "A HyperLogLog counter w/ %d registers" Int(counter.m)
+    return
+end
 
-		return HLL(m, M, mask, altmask, h)
-	end
+# Stream must be iterable
+function consume!(counter::HLL, stream::Any)
+    for v in stream
+        x = counter.h(v)
+        j = UInt32(UInt32(1) + (x & counter.mask))
+        w = x & counter.altmask
+        counter.M[j] = max(counter.M[j], rho(w))
+    end
+    return
+end
 
-	function Base.show(io::IO, counter::HLL)
-		@printf io "A HyperLogLog counter w/ %d registers" int(counter.m)
-		return
-	end
+function estimate(counter::HLL)
+    S = 0.0
+    
+    for j in 1:counter.m
+        S += 1 / (2^counter.M[j])
+    end
+    
+    Z = 1 / S
+    
+    E = alpha(counter.m) * counter.m^2 * Z
+    
+    if E <= 5//2 * counter.m
+        V = 0
+        for j in 1:counter.m
+            V += Int(counter.M[j] == 0x00000000)
+        end
+        if V != 0
+            E_star = counter.m * log(counter.m / V)
+        else
+            E_star = E
+        end
+    elseif E <= 1//30 * 2^32
+        E_star = E
+    else
+        E_star = -2^32 * log(1 - E / (2^32))
+    end
 
-	# Stream must be iterable
-	function consume!(counter::HLL, stream::Any)
-		for v in stream
-			x = counter.h(v)
-			j = uint32(uint32(1) + (x & counter.mask))
-			w = x & counter.altmask
-			counter.M[j] = max(counter.M[j], rho(w))
-		end
-		return
-	end
+    return E_star
+end
 
-	function estimate(counter::HLL)
-		S = 0.0
-
-		for j in 1:counter.m
-			S += 1 / (2^counter.M[j])
-		end
-
-		Z = 1 / S
-
-		E = alpha(counter.m) * counter.m^2 * Z
-
-		if E <= 5//2 * counter.m
-			V = 0
-			for j in 1:counter.m
-				V += int(counter.M[j] == 0x00000000)
-			end
-			if V != 0
-				E_star = counter.m * log(counter.m / V)
-			else
-				E_star = E
-			end
-		elseif E <= 1//30 * 2^32
-			E_star = E
-		else
-			E_star = -2^32 * log(1 - E / (2^32))
-		end
-
-		return E_star
-	end
-
-	# TODO: Figure out details here
-	# function confint(counter::HLL)
-	# 	e = estimate(counter)
-	# 	delta = e * 1.04 / sqrt(counter.m)
-	# 	return e - delta, e + delta
-	# end
+# TODO: Figure out details here
+# function confint(counter::HLL)
+# 	e = estimate(counter)
+# 	delta = e * 1.04 / sqrt(counter.m)
+# 	return e - delta, e + delta
+# end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,15 +1,24 @@
-hash32(d::Any) = uint32(hash(d))
 
-rho(s::Uint32) = uint32(uint32(leading_zeros(s)) + uint32(1))
+function num2byte(x::Union{Float16, Float32, Float64, Signed, Unsigned})
+    iob = IOBuffer()
+    write(iob, x)
+    seekstart(iob)
+    return readbytes(iob)
+end
 
-function alpha(m::Uint32)
-	if m == uint32(16)
-		return 0.673
-	elseif m == uint32(32)
-		return 0.697
-	elseif m == uint32(64)
-		return 0.709
-	else # if m >= uint32(128)
-		return 0.7213 / (1 + 1.079 / m)
-	end
+hash32(x::Number) = Murmur3.x86.hash32(num2byte(x))
+hash32(x::Union{AbstractString,Vector{UInt8}}) = Murmur3.x86.hash32(x)
+
+rho(s::UInt32) = UInt32(UInt32(leading_zeros(s)) + UInt32(1))
+
+function alpha(m::UInt32)
+    if m == UInt32(16)
+        return 0.673
+    elseif m == UInt32(32)
+        return 0.697
+    elseif m == UInt32(64)
+        return 0.709
+    else # if m >= uint32(128)
+        return 0.7213 / (1 + 1.079 / m)
+    end
 end

--- a/test/HyperLogLog.jl
+++ b/test/HyperLogLog.jl
@@ -21,7 +21,7 @@ for b in b_values
 	end
 end
 
-@assert cor(counts, repeat([1:n_points], outer = [n_b])) > 0.99
+@assert cor(counts, repeat(collect(1:n_points), outer = [n_b])) > 0.98
 
 # abs_errors = counts - is
 # rel_errors = (counts - is) ./ is

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,2 @@
+include("HyperLogLog.jl")
+include("utils.jl")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,16 +1,16 @@
-@assert HyperLogLog.isa(HyperLogLog.hash32("abc"), Uint32)
+@assert HyperLogLog.isa(HyperLogLog.hash32("abc"), UInt32)
 
-@assert HyperLogLog.rho(0x80000000) == uint32(1)
-@assert HyperLogLog.rho(0x40000000) == uint32(2)
-@assert HyperLogLog.rho(0x20000000) == uint32(3)
-@assert HyperLogLog.rho(0x10000000) == uint32(4)
-@assert HyperLogLog.rho(0x08000000) == uint32(5)
-@assert HyperLogLog.rho(0x04000000) == uint32(6)
-@assert HyperLogLog.rho(0x02000000) == uint32(7)
-@assert HyperLogLog.rho(0x01000000) == uint32(8)
-@assert HyperLogLog.rho(0x00000000) == uint32(33)
+@assert HyperLogLog.rho(0x80000000) == UInt32(1)
+@assert HyperLogLog.rho(0x40000000) == UInt32(2)
+@assert HyperLogLog.rho(0x20000000) == UInt32(3)
+@assert HyperLogLog.rho(0x10000000) == UInt32(4)
+@assert HyperLogLog.rho(0x08000000) == UInt32(5)
+@assert HyperLogLog.rho(0x04000000) == UInt32(6)
+@assert HyperLogLog.rho(0x02000000) == UInt32(7)
+@assert HyperLogLog.rho(0x01000000) == UInt32(8)
+@assert HyperLogLog.rho(0x00000000) == UInt32(33)
 
-@assert HyperLogLog.alpha(uint32(16)) == 0.673
-@assert HyperLogLog.alpha(uint32(32)) == 0.697
-@assert HyperLogLog.alpha(uint32(64)) == 0.709
-@assert HyperLogLog.alpha(uint32(128)) > 0.709
+@assert HyperLogLog.alpha(UInt32(16)) == 0.673
+@assert HyperLogLog.alpha(UInt32(32)) == 0.697
+@assert HyperLogLog.alpha(UInt32(64)) == 0.709
+@assert HyperLogLog.alpha(UInt32(128)) > 0.709


### PR DESCRIPTION
Update to Julia 0.4. There's still plenty of things to improve (in particular, hashing performance  for numbers, optimized support for other data types, etc.), but at least now it should run without errors on Julia 0.4.

The only thing except for compatibility that I've changed is using Murmur3 instead of Julia's native `hash` function. The primary reason for this is that Julia's `hash` returns `UInt64` (at least on my machine in current version of the language) and cannot be safely reduced to `UInt32`. Also Murmur3 seems to be quite popular choice for HLLs. 
